### PR TITLE
#38 Retry if failed

### DIFF
--- a/server.py
+++ b/server.py
@@ -58,6 +58,7 @@ def convert_video(gif_url, webhook):
                 requests.post(webhook, data=resources)
                 return
             except Exception as exc:
+                logging.debug('Retrying: Gif:{url} and Webhook:{webhook}'.format(url=gif_url, webhook=webhook));
                 convert_video.retry(exc=exc)
                 return
 

--- a/server.py
+++ b/server.py
@@ -42,6 +42,7 @@ celery = make_celery(app)
 def convert_video(gif_url, webhook):
     logging.debug('Converting video')
     parsed = urlparse.urlparse(webhook)
+    logging.debug('Converting: {}'.format(gif_url))
     logging.debug('Parsed webhook: {}'.format(parsed))
 
     if parsed.query:

--- a/src/video_manager.py
+++ b/src/video_manager.py
@@ -28,6 +28,7 @@ class VideoManager:
             if ext == 'ogv':
                 video.write_videofile(filename)
             else:
+                
                 urlopener.retrieve(converted_gif.get("%sUrl" % (ext)), filename)
 
         list_of_files['snapshot'] = saving_snapshot_filename


### PR DESCRIPTION
#38 
Sometime the conversion might take longer than usual. So, I set the retry so application can retry itself if something is wrong for maximum 3 times and 30 seconds delay. 

I believe we don't have to change anything in the plugin since if it's successful we're going to post it back to the `webhook` anyway?

@mpatek What do you think?