### PR TITLE
Fix URLError when Gfycat returns None in 'mp4Url' and 'webmUrl'

### DIFF
--- a/gif2html5/gfycat.py
+++ b/gif2html5/gfycat.py
@@ -20,6 +20,9 @@ def convert_gif(gif_url):
     if not all(k in data for k in ['mp4Url', 'webmUrl']):
         return None
 
+    if not all({k: v for k, v in data.items() if k in ['mp4Url', 'webmUrl']}.values()):
+        return None
+
     mp4 = data['mp4Url']
     webm = data['webmUrl']
 

--- a/gif2html5/gfycat.py
+++ b/gif2html5/gfycat.py
@@ -20,7 +20,7 @@ def convert_gif(gif_url):
     if not all(k in data for k in ['mp4Url', 'webmUrl']):
         return None
 
-    if not all({k: v for k, v in data.items() if k in ['mp4Url', 'webmUrl']}.values()):
+    if not all(v for k, v in data.items() if k in ['mp4Url', 'webmUrl']):
         return None
 
     mp4 = data['mp4Url']

--- a/tests/test_gfycat.py
+++ b/tests/test_gfycat.py
@@ -1,6 +1,6 @@
 import unittest
 
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from gif2html5.gfycat import convert_gif
 
@@ -37,3 +37,12 @@ class GfycatTests(unittest.TestCase):
 
         response = convert_gif(self.test_gif)
         self.assertEquals(None, response)
+
+    @patch('requests.get')
+    def test_urls_are_none(self, mock_request):
+        returned_json = {'mp4Url': None, 'webmUrl': None}
+        mock_request.return_value = mock_response = Mock()
+        mock_response.json.return_value = returned_json
+
+        response = convert_gif(self.test_gif)
+        self.assertEquals(response, None)

--- a/tests/test_gfycat.py
+++ b/tests/test_gfycat.py
@@ -46,3 +46,12 @@ class GfycatTests(unittest.TestCase):
 
         response = convert_gif(self.test_gif)
         self.assertEquals(response, None)
+
+    @patch('requests.get')
+    def test_one_of_the_url_is_none(self, mock_request):
+        returned_json = {'mp4Url': None, 'webmUrl': 'url'}
+        mock_request.return_value = mock_response = Mock()
+        mock_response.json.return_value = returned_json
+
+        response = convert_gif(self.test_gif)
+        self.assertEquals(response, None)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,7 @@ import server
 import unittest
 import requests
 
-from mock import MagicMock, ANY, patch
+from unittest.mock import MagicMock, ANY, patch
 from flask import json
 
 from gif2html5.config_parser import get_config


### PR DESCRIPTION
This results in  urllib.error.URLError: <urlopen error No such file or directory>

I fix this by checking if None is returned in 'mp4Url' and 'webmUrl',
then return None as convert_gif method will raise the exception so it
can be handled later.

I also changed the import in test_server to use unittest.mock instead of
mock as unittest.mock is included in Python 3.

See https://github.com/fusioneng/gif2html5-app/issues/55

Updated: 
So this won't result in URLOpener throwing `No such file or directory` anymore. 